### PR TITLE
Composer minimum PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.3",
         "symfony/class-loader": "2.1.*"
     },
     "autoload": {


### PR DESCRIPTION
Does Clinner require 5.3.9+ or 5.3+ ?
Current setting prevents developers with PHP version <5.3.9 from installing Clinner via Composer

I'm running the latest version in the Ubuntu repo
PHP 5.3.3-1ubuntu9.10 with Suhosin-Patch (cli) (built: Feb 11 2012 06:21:15)
## 

Your requirements could not be solved to an installable set of packages.

  Problem 1
    - ncuesta/clinner dev-master requires php >=5.3.9 -> no matching package found.
    - ncuesta/clinner dev-master requires php >=5.3.9 -> no matching package found.
